### PR TITLE
Add counters and improve sheet layout

### DIFF
--- a/css/crysborg.css
+++ b/css/crysborg.css
@@ -436,7 +436,6 @@
   width: 100%;
   min-height: 250px !important;
   height: 250px;
-  max-height: 350px;
   resize: vertical;
   overflow-y: auto;
 }
@@ -828,19 +827,26 @@
 }
 
 .structure-input-group,
-.hp-input-group {
+.hp-input-group,
+.powers-input-group,
+.silver-input-group {
   display: inline-flex;
-  align-items: stretch;
+  align-items: center;
+  vertical-align: middle;
 }
 
 .structure-input-group .structure-controls,
-.hp-input-group .hp-controls {
+.hp-input-group .hp-controls,
+.powers-input-group .powers-controls,
+.silver-input-group .silver-controls {
   display: flex;
   flex-direction: column;
 }
 
 .structure-input-group .structure-controls button,
-.hp-input-group .hp-controls button {
+.hp-input-group .hp-controls button,
+.powers-input-group .powers-controls button,
+.silver-input-group .silver-controls button {
   width: 16px;
   font-size: 10px;
   line-height: 10px;
@@ -849,10 +855,15 @@
   border: 1px solid var(--foreground-color);
   color: var(--foreground-color);
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .structure-input-group .structure-controls button:hover,
-.hp-input-group .hp-controls button:hover {
+.hp-input-group .hp-controls button:hover,
+.powers-input-group .powers-controls button:hover,
+.silver-input-group .silver-controls button:hover {
   color: var(--highlight-color);
   border-color: var(--highlight-color);
   background: var(--foreground-color);

--- a/css/crysborg.css
+++ b/css/crysborg.css
@@ -429,12 +429,15 @@
   text-align: left;
   margin: 0 0 4px;
 }
-/* GM-only notes editor starts at 120px tall, can grow up to 350px and
-   scrolls internally once that limit is reached. */
+/* Make GM-only notes editor resizable */
 .crysborg.sheet.actor .sheet-body .gm-description .editor,
 .crysborg.sheet.item .sheet-body .gm-description .editor {
   width: 100%;
-  min-height: 250px !important;
+}
+
+.crysborg.sheet.actor .sheet-body .gm-description .editor .editor-content,
+.crysborg.sheet.item .sheet-body .gm-description .editor .editor-content {
+  min-height: 250px;
   height: 250px;
   resize: vertical;
   overflow-y: auto;
@@ -797,39 +800,11 @@
   flex: 1;
 }
 
-.omens-decrement,
-.omens-increment {
-  background: var(--background-color);
-  border: 1px solid var(--foreground-color);
-  color: var(--foreground-color);
-  width: 20px;
-  height: 20px;
-  font-size: 12px;
-  font-weight: bold;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 2px;
-  transition: all 0.2s ease;
-}
-
-.omens-decrement:hover,
-.omens-increment:hover {
-  background: var(--foreground-color);
-  color: var(--background-color);
-  text-shadow: 0 0 5px var(--highlight-background-color);
-}
-
-.omens-decrement:active,
-.omens-increment:active {
-  transform: scale(0.95);
-}
-
 .structure-input-group,
 .hp-input-group,
 .powers-input-group,
-.silver-input-group {
+.silver-input-group,
+.omens-input-group {
   display: inline-flex;
   align-items: center;
   vertical-align: middle;
@@ -838,7 +813,8 @@
 .structure-input-group .structure-controls,
 .hp-input-group .hp-controls,
 .powers-input-group .powers-controls,
-.silver-input-group .silver-controls {
+.silver-input-group .silver-controls,
+.omens-input-group .omens-controls {
   display: flex;
   flex-direction: column;
 }
@@ -846,7 +822,8 @@
 .structure-input-group .structure-controls button,
 .hp-input-group .hp-controls button,
 .powers-input-group .powers-controls button,
-.silver-input-group .silver-controls button {
+.silver-input-group .silver-controls button,
+.omens-input-group .omens-controls button {
   width: 16px;
   font-size: 10px;
   line-height: 10px;
@@ -863,7 +840,8 @@
 .structure-input-group .structure-controls button:hover,
 .hp-input-group .hp-controls button:hover,
 .powers-input-group .powers-controls button:hover,
-.silver-input-group .silver-controls button:hover {
+.silver-input-group .silver-controls button:hover,
+.omens-input-group .omens-controls button:hover {
   color: var(--highlight-color);
   border-color: var(--highlight-color);
   background: var(--foreground-color);

--- a/css/crysborg.css
+++ b/css/crysborg.css
@@ -437,8 +437,8 @@
 
 .crysborg.sheet.actor .sheet-body .gm-description .editor .editor-content,
 .crysborg.sheet.item .sheet-body .gm-description .editor .editor-content {
-  min-height: 250px;
-  height: 250px;
+  min-height: 125px;
+  height: 125px;
   resize: vertical;
   overflow-y: auto;
 }
@@ -807,6 +807,10 @@
 .omens-input-group {
   display: inline-flex;
   align-items: center;
+  vertical-align: middle;
+}
+
+.hp-entries > input.stat-input {
   vertical-align: middle;
 }
 

--- a/module/actor/sheet/actor-sheet.js
+++ b/module/actor/sheet/actor-sheet.js
@@ -62,6 +62,10 @@ export default class MBActorSheet extends ActorSheet {
     html.find("button.reaction").on("click", this._onReactionRoll.bind(this));
     html.find("button.hp-increment").on("click", this._onHPIncrement.bind(this));
     html.find("button.hp-decrement").on("click", this._onHPDecrement.bind(this));
+    html.find("button.power-increment").on("click", this._onPowerIncrement.bind(this));
+    html.find("button.power-decrement").on("click", this._onPowerDecrement.bind(this));
+    html.find("button.silver-increment").on("click", this._onSilverIncrement.bind(this));
+    html.find("button.silver-decrement").on("click", this._onSilverDecrement.bind(this));
   }
 
   /** @override */
@@ -445,6 +449,51 @@ export default class MBActorSheet extends ActorSheet {
     const current = Number(input.val()) || 0;
     const newVal = Math.max(current - 1, 0);
     this.actor.update({ "system.hp.value": newVal });
+    input.val(newVal);
+  }
+
+  _onPowerIncrement(event) {
+    event.preventDefault();
+    const input = $(event.target)
+      .closest(".powers-input-group")
+      .find('input[name="system.powerUses.value"]');
+    const current = Number(input.val()) || 0;
+    const max = this.actor.system.powerUses?.max || 0;
+    const newVal = max ? Math.min(current + 1, max) : current + 1;
+    this.actor.update({ "system.powerUses.value": newVal });
+    input.val(newVal);
+  }
+
+  _onPowerDecrement(event) {
+    event.preventDefault();
+    const input = $(event.target)
+      .closest(".powers-input-group")
+      .find('input[name="system.powerUses.value"]');
+    const current = Number(input.val()) || 0;
+    const newVal = Math.max(current - 1, 0);
+    this.actor.update({ "system.powerUses.value": newVal });
+    input.val(newVal);
+  }
+
+  _onSilverIncrement(event) {
+    event.preventDefault();
+    const input = $(event.target)
+      .closest(".silver-input-group")
+      .find('input[name="system.silver"]');
+    const current = Number(input.val()) || 0;
+    const newVal = current + 1;
+    this.actor.update({ "system.silver": newVal });
+    input.val(newVal);
+  }
+
+  _onSilverDecrement(event) {
+    event.preventDefault();
+    const input = $(event.target)
+      .closest(".silver-input-group")
+      .find('input[name="system.silver"]');
+    const current = Number(input.val()) || 0;
+    const newVal = Math.max(current - 1, 0);
+    this.actor.update({ "system.silver": newVal });
     input.val(newVal);
   }
 }

--- a/module/actor/sheet/character-sheet.js
+++ b/module/actor/sheet/character-sheet.js
@@ -278,7 +278,10 @@ export class MBCharacterSheet extends MBActorSheet {
     const currentValue = this.actor.system.omens.value || 0;
     const newValue = currentValue + 1;
     this.actor.update({ "system.omens.value": newValue });
-    $(event.target).siblings('input[name="system.omens.value"]').val(newValue);
+    $(event.currentTarget)
+      .closest('.omens-input-group')
+      .find('input[name="system.omens.value"]')
+      .val(newValue);
   }
 
   _onOmensDecrement(event) {
@@ -286,7 +289,10 @@ export class MBCharacterSheet extends MBActorSheet {
     const currentValue = this.actor.system.omens.value || 0;
     const newValue = Math.max(currentValue - 1, 0);
     this.actor.update({ "system.omens.value": newValue });
-    $(event.target).siblings('input[name="system.omens.value"]').val(newValue);
+    $(event.currentTarget)
+      .closest('.omens-input-group')
+      .find('input[name="system.omens.value"]')
+      .val(newValue);
   }
 
   _onBroken(event) {

--- a/templates/actor/carriage/sheet-header.hbs
+++ b/templates/actor/carriage/sheet-header.hbs
@@ -14,7 +14,7 @@
     <div class="hitpoints-row">
       <div class="hp-entries">
         <span class="stat-label">{{ localize "MB.Structure" }}:</span>
-          <div class="structure-input-group omens-input-group">
+          <div class="structure-input-group">
             <div class="structure-controls">
               <button type="button" class="structure-increment">+</button>
               <button type="button" class="structure-decrement">-</button>

--- a/templates/actor/character/sheet-header.hbs
+++ b/templates/actor/character/sheet-header.hbs
@@ -32,7 +32,7 @@
     <div class="hitpoints-row">
       <div class="hp-entries">
         <span class="stat-label">{{ localize "MB.HP" }}:</span>
-          <div class="hp-input-group omens-input-group">
+          <div class="hp-input-group">
             <div class="hp-controls">
               <button type="button" class="hp-increment">+</button>
               <button type="button" class="hp-decrement">-</button>
@@ -61,7 +61,10 @@
           >{{ localize "MB.Omens" }}:</span
         >
         <div class="omens-input-group">
-          <button type="button" class="omens-decrement" title="{{ localize 'MB.DecrementOmens' }}">-</button>
+          <div class="omens-controls">
+            <button type="button" class="omens-increment" title="{{ localize 'MB.IncrementOmens' }}">+</button>
+            <button type="button" class="omens-decrement" title="{{ localize 'MB.DecrementOmens' }}">-</button>
+          </div>
           <input
             class="stat-input"
             name="system.omens.value"
@@ -69,7 +72,6 @@
             value="{{data.system.omens.value}}"
             data-dtype="Number"
           />
-          <button type="button" class="omens-increment" title="{{ localize 'MB.IncrementOmens' }}">+</button>
         </div>
       </div>    
     </div>

--- a/templates/actor/character/sheet-header.hbs
+++ b/templates/actor/character/sheet-header.hbs
@@ -73,28 +73,40 @@
         </div>
       </div>    
     </div>
-    <div class="hitpoints-row">
-      <div class="powers-block">
-        <label class="stat-label uses-remaining-label">{{localize "MB.PowerUsesRemaining"}}:</label>
-        <input
-          class="stat-input"
-          name="system.powerUses.value"
-          type="number"
-          value="{{data.system.powerUses.value}}"
-          data-dtype="Number"
-        />
-      </div> 
-      <div class="silver">
-        <span class="stat-label silver-label">{{ localize "MB.Silver" }}:</span>
-        <input
-          class="stat-input silver-input"
-          name="system.silver"
-          type="number"
-          value="{{data.system.silver}}"
-          data-dtype="Number"
-        />
-      </div>         
-    </div>
+      <div class="hitpoints-row">
+        <div class="powers-block">
+          <label class="stat-label uses-remaining-label">{{localize "MB.PowerUsesRemaining"}}:</label>
+          <div class="powers-input-group">
+            <div class="powers-controls">
+              <button type="button" class="power-increment">+</button>
+              <button type="button" class="power-decrement">-</button>
+            </div>
+            <input
+              class="stat-input"
+              name="system.powerUses.value"
+              type="number"
+              value="{{data.system.powerUses.value}}"
+              data-dtype="Number"
+            />
+          </div>
+        </div>
+        <div class="silver">
+          <span class="stat-label silver-label">{{ localize "MB.Silver" }}:</span>
+          <div class="silver-input-group">
+            <div class="silver-controls">
+              <button type="button" class="silver-increment">+</button>
+              <button type="button" class="silver-decrement">-</button>
+            </div>
+            <input
+              class="stat-input silver-input"
+              name="system.silver"
+              type="number"
+              value="{{data.system.silver}}"
+              data-dtype="Number"
+            />
+          </div>
+        </div>
+      </div>
     <div class="buttons-row">
 
       <button

--- a/templates/actor/common/npc-header.hbs
+++ b/templates/actor/common/npc-header.hbs
@@ -20,7 +20,7 @@
       </div>
       <div class="hitpoints-row">
         <span class="stat-label">{{ localize "MB.HitPoints" }}:</span>
-        <div class="hp-input-group omens-input-group">
+        <div class="hp-input-group">
           <div class="hp-controls">
             <button type="button" class="hp-increment">+</button>
             <button type="button" class="hp-decrement">-</button>

--- a/templates/actor/follower-sheet.hbs
+++ b/templates/actor/follower-sheet.hbs
@@ -100,13 +100,19 @@
           <span class="stat-label silver-label"
             >{{ localize "MB.Silver" }}:</span
           >
-          <input
-            class="stat-input silver-input"
-            name="system.silver"
-            type="number"
-            value="{{data.system.silver}}"
-            data-dtype="Number"
-          />
+          <div class="silver-input-group">
+            <div class="silver-controls">
+              <button type="button" class="silver-increment">+</button>
+              <button type="button" class="silver-decrement">-</button>
+            </div>
+            <input
+              class="stat-input silver-input"
+              name="system.silver"
+              type="number"
+              value="{{data.system.silver}}"
+              data-dtype="Number"
+            />
+          </div>
         </div>
       </div>
       <ol class="items-list equipment-list">

--- a/templates/item/carriage-class-sheet.hbs
+++ b/templates/item/carriage-class-sheet.hbs
@@ -1,43 +1,39 @@
 <form class="flexcol {{cssClass}}" autocomplete="off">
   {{> systems/crysborg/templates/item/common/sheet-header.hbs }}
+  {{> systems/crysborg/templates/item/common/sheet-tabs.hbs }}
+
   <section class="sheet-body">
-    <div class="form-group">
-      <label>{{ localize "MB.Description" }}:</label>
-      <textarea name="system.description" rows="4">{{data.system.description}}</textarea>
-      {{#if @root.isGM}}
-      <div class="form-group gm-description">
-        <label>{{ localize "MB.GMDescription" }}</label>
-        {{editor flags.crysborg.gmdescription target="flags.crysborg.gmdescription" button=true owner=owner editable=true engine="prosemirror"}}
+    {{> systems/crysborg/templates/common/description-tab.hbs }}
+
+    <div class="tab" data-group="primary" data-tab="details">
+      <div class="form-group">
+        <label>{{localize 'MB.AbilitySpeed'}}:</label>
+        <input type="text" name="system.speed" value="{{data.system.speed}}" data-dtype="String" />
       </div>
-      {{/if}}
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MB.AbilitySpeed'}}:</label>
-      <input type="text" name="system.speed" value="{{data.system.speed}}" data-dtype="String" />
-    </div>
-    <div class="form-group">
-      <label>Ram:</label>
-      <input type="text" name="system.ram" value="{{data.system.ram}}" data-dtype="String" />
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MB.Structure'}}:</label>
-      <input type="text" name="system.structure" value="{{data.system.structure}}" data-dtype="String" />
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MB.AbilityStability'}}:</label>
-      <input type="text" name="system.stability" value="{{data.system.stability}}" data-dtype="String" />
-    </div>
-    <div class="form-group">
-      <label>{{localize 'MB.Armor'}}:</label>
-      <input type="text" name="system.armor" value="{{data.system.armor}}" data-dtype="String" />
-    </div>
-    <div class="form-group">
-      <label>Cargo Capacity:</label>
-      <input type="text" name="system.cargo" value="{{data.system.cargo}}" data-dtype="Number" />
-    </div>
-    <div class="form-group">
-      <label>Cost:</label>
-      <input type="text" name="system.cost" value="{{data.system.cost}}" data-dtype="String" />
+      <div class="form-group">
+        <label>Ram:</label>
+        <input type="text" name="system.ram" value="{{data.system.ram}}" data-dtype="String" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MB.Structure'}}:</label>
+        <input type="text" name="system.structure" value="{{data.system.structure}}" data-dtype="String" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MB.AbilityStability'}}:</label>
+        <input type="text" name="system.stability" value="{{data.system.stability}}" data-dtype="String" />
+      </div>
+      <div class="form-group">
+        <label>{{localize 'MB.Armor'}}:</label>
+        <input type="text" name="system.armor" value="{{data.system.armor}}" data-dtype="String" />
+      </div>
+      <div class="form-group">
+        <label>Cargo Capacity:</label>
+        <input type="text" name="system.cargo" value="{{data.system.cargo}}" data-dtype="Number" />
+      </div>
+      <div class="form-group">
+        <label>Cost:</label>
+        <input type="text" name="system.cost" value="{{data.system.cost}}" data-dtype="String" />
+      </div>
     </div>
   </section>
 </form>

--- a/templates/item/carriage-upgrade-sheet.hbs
+++ b/templates/item/carriage-upgrade-sheet.hbs
@@ -1,17 +1,11 @@
 <form class="flexcol {{cssClass}}" autocomplete="off">
   {{> systems/crysborg/templates/item/common/sheet-header.hbs }}
+  {{> systems/crysborg/templates/item/common/sheet-tabs.hbs }}
+
   <section class="sheet-body">
-    <div class="tab">
-      <div class="form-group">
-        <label>{{ localize "MB.Description" }}:</label>
-        <textarea name="system.description" rows="4">{{data.system.description}}</textarea>
-        {{#if @root.isGM}}
-        <div class="form-group gm-description">
-          <label>{{ localize "MB.GMDescription" }}</label>
-          {{editor flags.crysborg.gmdescription target="flags.crysborg.gmdescription" button=true owner=owner editable=true engine="prosemirror"}}
-        </div>
-        {{/if}}
-      </div>
+    {{> systems/crysborg/templates/common/description-tab.hbs }}
+
+    <div class="tab" data-group="primary" data-tab="details">
       <div class="form-group">
         <label>Location:</label>
         <select name="system.location" data-dtype="String">


### PR DESCRIPTION
## Summary
- Add description tab and layout to carriage fitting items
- Make GM notes resizable and align HP/structure counters
- Add increment buttons for power uses and silver, centering counter icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bfc857808324b537d1bd9e9fa966