### PR TITLE
Add draft speed support for non-character actors

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -90,7 +90,7 @@
   "MB.FollowerSpeciality": "Speciality",
   "MB.FollowerTrait": "Trait",
   "MB.FollowerValue": "Value",
-  "MB.FollowerCarriageSpeed": "Carriage Speed",
+  "MB.ActorSpeed": "Speed",
   "MB.GetBetter": "Get Better",
   "MB.HandedOne": "One-handed",
   "MB.HandedTwo": "Two-handed",

--- a/template.json
+++ b/template.json
@@ -28,7 +28,8 @@
         "hp": {
           "max": 1,
           "value": 1
-        }
+        },
+        "speed": 0
       }
     },
     "character": {
@@ -57,7 +58,8 @@
         "value": 0
       },
       "description": "",
-      "price": ""
+      "price": "",
+      "speed": 0
     },
     "creature": {
       "templates": ["common"],
@@ -74,8 +76,7 @@
       "silver": 0,
       "speciality": "",
       "trait": "",
-      "value": "",
-      "carriageSpeed": 0
+      "value": ""
     },
     "carriage": {
       "abilities": {

--- a/templates/actor/carriage/cargo-tab.hbs
+++ b/templates/actor/carriage/cargo-tab.hbs
@@ -23,12 +23,12 @@
       <h3 class="item-name flexrow">{{localize 'MB.DraftSlot'}}</h3>
     </li>
     <ol class="item-list">
-      {{#each data.system.draftActors as |follower|}}
-        <li class="item flexrow" data-follower-id="{{follower.id}}">
-          <img src="{{follower.img}}" title="{{follower.name}}" width="24" height="24" />
-          <h4 class="item-name follower-open">{{follower.name}}</h4>
+      {{#each data.system.draftActors as |draftActor|}}
+        <li class="item flexrow" data-draft-actor-id="{{draftActor.id}}">
+          <img src="{{draftActor.img}}" title="{{draftActor.name}}" width="24" height="24" />
+          <h4 class="item-name draft-open">{{draftActor.name}}</h4>
           <div class="item-controls">
-            <a class="follower-remove" title="{{localize 'MB.Remove'}}"><i class="fas fa-trash"></i></a>
+            <a class="draft-remove" title="{{localize 'MB.Remove'}}"><i class="fas fa-trash"></i></a>
           </div>
         </li>
       {{/each}}

--- a/templates/actor/container-sheet.hbs
+++ b/templates/actor/container-sheet.hbs
@@ -67,6 +67,17 @@
         />
       </div>
 
+      <div class="form-group">
+        <label>{{ localize "MB.ActorSpeed" }}:</label>
+        <input
+          type="number"
+          name="system.speed"
+          value="{{data.system.speed}}"
+          placeholder="0"
+          data-dtype="Number"
+        />
+      </div>
+
       {{!-- Tags system disabled --}}
       {{!--
       <div class="form-group">

--- a/templates/actor/creature-sheet.hbs
+++ b/templates/actor/creature-sheet.hbs
@@ -27,6 +27,18 @@
         />
       </div>
 
+      {{!-- Speed --}}
+      <div class="form-group">
+        <label>{{ localize "MB.ActorSpeed" }}:</label>
+        <input
+          name="system.speed"
+          type="number"
+          value="{{data.system.speed}}"
+          placeholder="0"
+          data-dtype="Number"
+        />
+      </div>
+
       {{!-- Armor --}}
       <div class="form-group">
         <label>{{ localize "MB.CreatureArmor" }}:</label>

--- a/templates/actor/follower-sheet.hbs
+++ b/templates/actor/follower-sheet.hbs
@@ -65,13 +65,13 @@
         />
       </div>
 
-      {{!-- Carriage Speed --}}
+      {{!-- Speed --}}
       <div class="form-group">
-        <label>{{ localize "MB.FollowerCarriageSpeed" }}:</label>
+        <label>{{ localize "MB.ActorSpeed" }}:</label>
         <input
           type="number"
-          name="system.carriageSpeed"
-          value="{{data.system.carriageSpeed}}"
+          name="system.speed"
+          value="{{data.system.speed}}"
           placeholder="0"
           data-dtype="Number"
         />


### PR DESCRIPTION
## Summary
- add a reusable draft speed helper and persist speed values for non-character actors
- expose speed inputs on follower, creature, and container sheets with shared localization
- allow characters and other actor types to be drafted onto carriages while updating the UI wording

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9de6268148324ada30119f0be12d0